### PR TITLE
fixing strict strategy: correct message when warnings are present

### DIFF
--- a/src/de/otto/status.clj
+++ b/src/de/otto/status.clj
@@ -25,7 +25,7 @@
   (aggregate-forgiving {:ok "at least one ok" :error "none ok"} list))
 
 (defn strict-strategy [list]
-  (aggregate-strictly {:ok "all ok" :warnings "some warnings" :error "none ok"} list))
+  (aggregate-strictly {:ok "all ok" :warning "some warnings" :error "none ok"} list))
 
 (defn aggregate-status
   ([id strategy funs] (aggregate-status id strategy funs {}))

--- a/test/de/otto/status_test.clj
+++ b/test/de/otto/status_test.clj
@@ -2,6 +2,9 @@
   (:require [clojure.test :refer :all]
             [de.otto.status :as s]))
 
+(def f-ok (fn [] {:ok-subcomponent {:status :ok :message "all ok"}}))
+(def f-warn (fn [] {:warn-subcomponent {:status :warning :message "a warning"}}))
+
 (def s-ok {:ok-subcomponent {:status :ok :message "all ok"}})
 (def s-ok2 {:ok-subcomponent2 {:status :ok :message "all ok"}})
 (def s-warn {:warn-subcomponent {:status :warning :message "a warning"}})
@@ -71,3 +74,11 @@
                             :warn-subcomponent  {:status :warning :message "a warning"}}}
            (s/aggregate-strictly
              strict-msgs (merge s-ok s-error s-warn))))))
+
+(deftest integrated-aggregate-status-with-strict-strategy
+  (testing "warn-if-any-warning"
+    (is (= {:id 
+             {:status        :warning :message "some warnings"
+              :statusDetails {:ok-subcomponent  {:status :ok :message "all ok"}
+                              :warn-subcomponent {:status :warning :message "a warning"}}}}
+           (s/aggregate-status :id s/strict-strategy [f-ok f-warn])))))


### PR DESCRIPTION
there was a minor error in the strict-strategy, that caused the message to be nil, when it should be "some warnings".

I added a test for that.
